### PR TITLE
Multiple kettles and pumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/cgspeck/cbpi-alarm-clock.svg?branch=master)](https://travis-ci.org/cgspeck/cbpi-alarm-clock)
 
-This allows you to set up your equipment and water in advance and have the process pause until a set time.
+This allows you to set up your equipment and water in advance and have the process pause until a set time. It will automatically find your kettles and set them to 0, and find your actors and switch them off.
 
 ## Parameters
 
@@ -10,4 +10,11 @@ This allows you to set up your equipment and water in advance and have the proce
 * `timezone`: you must select your local timezone from the dropdown. Only fixed a timezone is supported, you will need to adjust this for Daylight Savings.
 * `start_hour` and `start_minute`: when to resume the brew
 * `force_off_at_start`: if `enabled` will switch off pump and set target temp to 0 at start of paused period
-* `kettle` and `pump`: if `force_off_at_start` is enabled, set the corresponding pump and kettle for this brew
+* `actors_to_ignore`: a comma seperated list of actors to ignore while scanning if `force_off_at_start` is enabled
+
+## Version History
+
+2.0.0 - This version removes pump & kettle selection and instead
+        uses the cache to find your brewing equipment.
+
+1.0.0 - Initial release, control a single pump and kettle only.

--- a/__init__.py
+++ b/__init__.py
@@ -127,9 +127,6 @@ SELECTABLE_TIMEZONES =[
 
 NOTICE_DATE_FORMAT = '%-d %b %y, %-I:%M %p'
 
-KETTLE_DESC = 'Optional, selected kettle temp will be set to 0c until alarm expires.'
-
-PUMP_DESC = 'Optional, selected kettle temp will be switch off until alarm expires.'
 
 @cbpi.step
 class AlarmClockStep(StepBase):

--- a/__init__.py
+++ b/__init__.py
@@ -131,7 +131,6 @@ NOTICE_DATE_FORMAT = '%-d %b %y, %-I:%M %p'
 @cbpi.step
 class AlarmClockStep(StepBase):
     mode = Property.Select("Mode", options=["disabled", "enabled"], description="If enabled then this step will block until after the set time.")
-
     timezone = Property.Select(
         "Your Timezone",
         options=SELECTABLE_TIMEZONES,
@@ -139,8 +138,8 @@ class AlarmClockStep(StepBase):
     )
     start_hour = Property.Select("Start Hour", options=list(range(23)))
     start_minute = Property.Select("Start Minute", options=list(range(0, 60, 5)))
-    force_off_at_start = Property.Select("Force off at start", options=["disabled", "enabled"], description="If enabled then this step will switch off selected pump(s) and set temperature(s) to 0 when it starts.")
-    zzz_actor_blacklist = Property.Text("Actors to ignore", configurable=True, default_value="", description="Comma seperated list of actors to ignore, e.g. 'system_fan, indicator_light'")
+    force_off_at_start = Property.Select("Force off at start", options=["disabled", "enabled"], description="If enabled then this step will switch off all actors and set the temperature of all kettles to 0c when it starts.")
+    zzz_actor_blacklist = Property.Text("Excluded actors", configurable=True, default_value="", description="Comma seperated list of actors to ignore, e.g. 'system fan, aux pump, anti freeze element'")
 
     def __init__(self, *args, **kwds):
         StepBase.__init__(self, *args, **kwds)

--- a/__init__.py
+++ b/__init__.py
@@ -218,9 +218,10 @@ class AlarmClockStep(StepBase):
 
     def switch_off_pumps(self, list_of_pumps):
         res = []
+        actors = self.api.cache.get('actors')
         for pump_str in list_of_pumps:
             pump_idx = self.get_device_index_if_configured(pump_str)
-
+            # todo check that the pump_idx exists as a key in actors
             if pump_idx:
                 try:
                     self.actor_off(pump_idx)

--- a/__init__.py
+++ b/__init__.py
@@ -212,7 +212,7 @@ class AlarmClockStep(StepBase):
                 for kettle_str in ['kettle', 'kettle2', 'kettle3']:
                     kettle_idx = self.get_device_index_if_configured(kettle_str)
 
-                    if kettle_idx:
+                    if kettle_idx and self.get_target_temp(kettle_idx):
                         self._logger.info("AlarmClock: setting kettle index %s to 0c" % kettle_idx)
                         self.set_target_temp(0, kettle_idx)
 

--- a/__init__.py
+++ b/__init__.py
@@ -145,7 +145,7 @@ class AlarmClockStep(StepBase):
     def __init__(self, *args, **kwds):
         StepBase.__init__(self, *args, **kwds)
         self._logger = logging.getLogger(type(self).__name__)
-        self._normalised_actor_blacklist = None
+        self._normalised_actor_blacklist = []
 
     def init(self):
         if self.mode == "enabled":
@@ -201,14 +201,18 @@ class AlarmClockStep(StepBase):
                 for kettle in self.api.cache.get('kettle').keys():
                     self.set_target_temp(0, kettle)
 
-                self._normalised_actor_blacklist = self.normalise_actor_blacklist()
+                if isinstance(self.zzz_actor_blacklist, unicode):
+                    self._normalised_actor_blacklist = self.normalise_actor_blacklist(self.zzz_actor_blacklist)
+
                 # switch actors off
                 self.switch_off_actors()
 
-    def normalise_actor_blacklist(self):
+    @staticmethod
+    def normalise_actor_blacklist(raw_list):
         res = []
-        if isinstance(self.zzz_actor_blacklist, unicode):
-            for blacklist_entry in self.zzz_actor_blacklist.split(','):
+
+        for blacklist_entry in raw_list.split(','):
+            if len(blacklist_entry) > 0:
                 res.append(blacklist_entry.strip().lower())
 
         return res

--- a/tests/test_normalise_actor_blacklist.py
+++ b/tests/test_normalise_actor_blacklist.py
@@ -1,0 +1,37 @@
+import unittest
+
+import datetime
+
+from modules.plugins.cbpi_alarm_clock import AlarmClockStep
+
+class TestNormaliseActorBlacklist(unittest.TestCase):
+
+    def test_blank_list(self):
+        property_value = ""
+        expected = []
+
+        self.assertEqual(
+            AlarmClockStep.normalise_actor_blacklist(property_value),
+            expected
+        )
+
+    def test_single_item(self):
+        property_value = "some actor"
+        expected = ["some actor"]
+
+        self.assertEqual(
+            AlarmClockStep.normalise_actor_blacklist(property_value),
+            expected
+        )
+
+    def test_multiple_items(self):
+        property_value = "  some ACTOR,   some OTHER thing  "
+        expected = ["some actor", "some other thing"]
+
+        self.assertEqual(
+            AlarmClockStep.normalise_actor_blacklist(property_value),
+            expected
+        )
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Use the `self.api.cache` to discover kettles and actors and switch them off while alarm is running.

Add blacklist capability for actors.

Removed unncessary config and update documentation.

Closes #3 